### PR TITLE
Fix alpha form success message

### DIFF
--- a/beta-tester-form.html
+++ b/beta-tester-form.html
@@ -305,16 +305,16 @@
                     <button type="submit" class="btn btn-primary" id="submitBtn" style="display: none;">Submit Application</button>
                 </div>
             </form>
-            
-            <!-- Success Message -->
-            <div class="success-message" id="successMessage">
-                <div class="success-icon">
-                    <i class="fas fa-check-circle"></i>
-                </div>
-                <h2>Application Submitted Successfully!</h2>
-                <p>Thank you for your interest in the BioAnalytiX alpha program. We'll review your application and get back to you within 48 hours.</p>
-                <a href="/" class="btn btn-primary">Back to Home</a>
+        </div>
+
+        <!-- Success Message -->
+        <div class="success-message" id="successMessage">
+            <div class="success-icon">
+                <i class="fas fa-check-circle"></i>
             </div>
+            <h2>Application Submitted Successfully!</h2>
+            <p>Thank you for signing up for the BioAnalytiX Alpha version. We have received your application and will review it shortly.</p>
+            <a href="/" class="btn btn-primary">Back to Home</a>
         </div>
     </section>
 

--- a/beta-tester-form/index.html
+++ b/beta-tester-form/index.html
@@ -315,26 +315,26 @@
                     <button type="submit" class="btn btn-primary" id="submitBtn" style="display: none;">Submit Application</button>
                 </div>
             </form>
-            
-            <!-- Success Message -->
-            <div class="success-message" id="successMessage">
-                <div class="success-icon">
-                    <i class="fas fa-check-circle"></i>
-                </div>
-                <h2>Application Submitted Successfully!</h2>
-                <p>Thank you for your interest in the BioAnalytiX alpha program. We've received your application and will review it carefully.</p>
-                <div class="success-details">
-                    <p><strong>📧 Confirmation:</strong> Your application has been sent to our team at <a href="mailto:info@bioanalytix.info">info@bioanalytix.info</a></p>
-                    <p><strong>⏰ What happens next?</strong></p>
-                    <ul>
-                        <li>We'll review your application within 1 week</li>
-                        <li>If selected, you'll receive access instructions via email</li>
-                        <li>Alpha testing begins in September 2025</li>
-                    </ul>
-                    <p><strong>❓ Questions?</strong> Contact us at <a href="mailto:info@bioanalytix.info">info@bioanalytix.info</a></p>
-                </div>
-                <a href="/" class="btn btn-primary">Back to Home</a>
+        </div>
+
+        <!-- Success Message -->
+        <div class="success-message" id="successMessage">
+            <div class="success-icon">
+                <i class="fas fa-check-circle"></i>
             </div>
+            <h2>Application Submitted Successfully!</h2>
+            <p>Thank you for signing up for the BioAnalytiX Alpha version. We have received your application and will review it shortly.</p>
+            <div class="success-details">
+                <p><strong>📧 Confirmation:</strong> Your application has been sent to our team at <a href="mailto:info@bioanalytix.info">info@bioanalytix.info</a></p>
+                <p><strong>⏰ What happens next?</strong></p>
+                <ul>
+                    <li>We'll review your application within 1 week</li>
+                    <li>If selected, you'll receive access instructions via email</li>
+                    <li>Alpha testing begins in September 2025</li>
+                </ul>
+                <p><strong>❓ Questions?</strong> Contact us at <a href="mailto:info@bioanalytix.info">info@bioanalytix.info</a></p>
+            </div>
+            <a href="/" class="btn btn-primary">Back to Home</a>
         </div>
     </section>
 

--- a/test-success-message.html
+++ b/test-success-message.html
@@ -41,7 +41,7 @@
             <i class="fas fa-check-circle"></i>
         </div>
         <h2>Application Submitted Successfully!</h2>
-        <p>Thank you for your interest in the BioAnalytiX alpha program. We've received your application and will review it carefully.</p>
+        <p>Thank you for signing up for the BioAnalytiX Alpha version. We have received your application and will review it shortly.</p>
         <div class="success-details">
             <p><strong>📧 Confirmation:</strong> Your application has been sent to our team at <a href="mailto:info@bioanalytix.info">info@bioanalytix.info</a></p>
             <p><strong>⏰ What happens next?</strong></p>


### PR DESCRIPTION
## Summary
- clarify confirmation text for Alpha signup
- move the success message outside the form container so it appears after submission

## Testing
- `bash test-beta-form-web3forms.sh` *(fails: CONNECT tunnel failed)*
- `bash test-beta-form.sh` *(fails: command not found: open)*

------
https://chatgpt.com/codex/tasks/task_e_684f3c68aa44833086f6b6da37cddf17